### PR TITLE
Create requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,18 @@ and then source the script into your shell:
 
 ## Interactive script
 
-First install [InquirerPy](https://pypi.org/project/inquirerpy/):
+First install the [InquirerPy](https://pypi.org/project/inquirerpy/)
+and the requests modules:
 
 ```
 pip3 install InquirerPy
+pip3 install requests
+```
+
+Or, by using the `requirements.txt`:
+
+```
+pip3 install -r requirements.txt
 ```
 
 Then run:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+InquirerPy
+requests


### PR DESCRIPTION
**- What I did**
I created a `requirements.txt` file to make de depedency management easier. The first time I ran the `dump_cards.py` it complained that it didn't find the `requests` module, because I use virtual envs with nothing but the required packages.

**- How I did it**
I did it by addind the required python modules to a `requirements.txt` file.

**- How to verify it**
Create a new virtual env with no packages installed. Run `pip install -r requirements.txt` and run the `dump_cards.py`

**- Description for the changelog**
Create requirements.txt