### PR TITLE
Get dependabot to keep an eye on requirements.txt

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
**- What I did**

Added dependabot config and specified pip ecosystem

**- How I did it**

Followed https://jonahlawrence.hashnode.dev/keeping-your-dependencies-updated-automatically-with-dependabot

**- How to verify it**

Watch out for PRs from dependabot

**- Description for the changelog**

Get dependabot to keep an eye on requirements.txt